### PR TITLE
Separated deploy and build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -121,7 +121,7 @@ gulp.task('build', ['clean'], function() {
   gulp.start('contributors', 'bower', 'copy', 'jade', 'stylus');
 });
 
-gulp.task('deploy', ['build'], function() {
+gulp.task('deploy', function() {
   return gulp.src('./dist/**/*')
     .pipe(ghPages());
 });


### PR DESCRIPTION
This fixes an issue with the build steps not happening in order. Build doesn't finish before deploy is ran so the build directory is empty for the deploy.

There's probably a better way to fix this, but this will allow deploys to happen for the time being.