### PR TITLE
Change tagboard to juicer social feed

### DIFF
--- a/src/styl/sections/community.styl
+++ b/src/styl/sections/community.styl
@@ -1,6 +1,6 @@
 //- COMMUNITY PAGE ----------------------------------------------- //
 
-//- Tagboard feed
-#tagboard-embed
-  padding: 20px 10px
+//- Juicer feed
+#juicer-embed
+  padding: 20px
   background: $grey-5

--- a/src/views/community/index.jade
+++ b/src/views/community/index.jade
@@ -16,7 +16,8 @@ block content
         h3 Share yours with <a href="https://twitter.com/search?q=%23whyaz&amp;src=typd">#whyaz</a>.
 
     .flex-1of1
-      #tagboard-embed
+      #juicer-embed
 
-  script var tagboardOptions = {tagboard:"whyaz/194612", darkMode: true};
-  script(src="https://tagboard.com/public/js/embed.js")
+        script(src="//assets.juicer.io/embed.js" type="text/javascript")
+        link(href="//assets.juicer.io/embed.css" media="all" rel="stylesheet" type="text/css")
+        ul(class="juicer-feed" data-feed-id="whyaz")


### PR DESCRIPTION
For this issue: https://github.com/whyaz/whyaz/issues/48

Juicer seems like a good alternative. Posts update every 24 hours. If we want it to update more frequently we could do the $20 a month option.

![image](https://cloud.githubusercontent.com/assets/871315/24917220/54360712-1e91-11e7-904d-04b52bc96540.png)
